### PR TITLE
Remove confusing reference to branch name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,4 @@ By submitting a PR to this repository, you agree to the terms within the [Auth0 
 
 - [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
 - [ ] All active GitHub checks for tests, formatting, and security are passing
-- [ ] The correct base branch is being used, if not `master`
+- [ ] The correct base branch is being used, if not the default branch


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Some auth0 repositories use `master` as the default branch, e.g.:
* [auth0/lock](https://github.com/auth0/lock/branches)
* [auth0/Lock.swift](https://github.com/auth0/Lock.swift/branches)

Others use `main`, e.g.:
* [auth0/Lock.Android](https://github.com/auth0/Lock.Android/branches)
* [auth0/auth0-cli](https://github.com/auth0/auth0-cli/branches)

Mentioning `master` in a generic template that's shared between both kinds of repositories results in some pretty confusing messaging.

Afaict, the text is trying to mean `the default branch`, so instead of writing `master`, this PR changes the prose to match the intention.

### Testing

I've looked at the wording.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
